### PR TITLE
Add Thai subtitle font support

### DIFF
--- a/smarttubetv/src/main/assets/NotoSansThai-Regular.ttf
+++ b/smarttubetv/src/main/assets/NotoSansThai-Regular.ttf
@@ -1,0 +1,1 @@
+TODO: Replace with actual NotoSansThai-Regular.ttf font file

--- a/smarttubetv/src/main/java/com/liskovsoft/smartyoutubetv2/tv/ui/playback/PlaybackFragment.java
+++ b/smarttubetv/src/main/java/com/liskovsoft/smartyoutubetv2/tv/ui/playback/PlaybackFragment.java
@@ -464,7 +464,7 @@ public class PlaybackFragment extends SeekModePlaybackFragment implements Playba
     }
 
     private void createSubtitleManager() {
-        mSubtitleManager = new SubtitleManager(getActivity(), R.id.leanback_subtitles);
+        mSubtitleManager = new SubtitleManager(getActivity(), R.id.leanback_subtitles, mExoPlayerController);
 
         // subs renderer
         if (mPlayer.getTextComponent() != null) {


### PR DESCRIPTION
## Summary
- add placeholder NotoSansThai font asset
- load Thai font for subtitle rendering when current track language is Thai

## Testing
- `bash gradlew test` *(fails: Unable to tunnel through proxy, HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68945e9fb244832b9d3e94262778880a